### PR TITLE
Fix README.rst extra '('

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Instantiate the API::
 
 Invoke a method::
 
-    >>> data = api.catalog.products((['1004004011187773', '1004004011231766'])
+    >>> data = api.catalog.products(['1004004011187773', '1004004011231766'])
 
 JSON data is returned "as is":
 


### PR DESCRIPTION
Hi, i view that README.rst file in the part where explain the use for OpenApi call for products, you have a double parenthesis, i delete one, because maybe is a error.