### PR TITLE
fix(plaza): stop using deprecated `getchildren` method

### DIFF
--- a/bol/plaza/models.py
+++ b/bol/plaza/models.py
@@ -61,7 +61,7 @@ class Model(object):
     def parse(cls, api, xml):
         m = cls()
         m.xml = xml
-        for element in xml.getchildren():
+        for element in xml:
             if '}' in element.tag:
                 tag = element.tag.partition('}')[2]
             elif ':' in element.tag:
@@ -80,7 +80,7 @@ class ModelList(list, Model):
         ml = cls()
         ml.xml = xml
         item_tag = getattr(ml.Meta, 'item_type_tag', None)
-        for element in xml.getchildren():
+        for element in xml:
             if item_tag and item_tag != element.tag:
                 continue
             ml.append(ml.Meta.item_type.parse(api, element))


### PR DESCRIPTION
According to [docs](https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren), `getchildren` method is deprecated since python 3.2 and should be replaced with simple iteration. It is being removed in python 3.9, so it will help with migration if this deprecation warning will be addressed :)